### PR TITLE
feat: configure multiple custom utilities in a single function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-This Tailwind CSS plugin allows you to write configuration for your own custom utility in the `theme` and `variants` section of your config as though it were actually part of the framework. Just define it with a single line in the `plugins` section! 
+This Tailwind CSS plugin allows you to write configuration for your own custom utility in the `theme` and `variants` section of your config as though it were actually part of the framework. Just define it with a single line in the `plugins` section!
 
 This should allow you to finally kill off leftover CSS and inline styles that have no accompanying plugin-made or native utility. Although you can replace other [plugins](https://github.com/aniftyco/awesome-tailwindcss#plugins) with this one, it's probably a good idea to use those instead because they're purpose-built and likely to create a better output.
 
 ## Installation
+
 ```bash
 npm install --save-dev tailwindcss-custom-native
 ```
 
 ## Basic usage
+
 With this Tailwind configuration,
 
 ```js
@@ -16,25 +18,26 @@ const customNative = require('tailwindcss-custom-native');
 module.exports = {
   theme: {
     ...,
-    
+
     // This utility is not native to Tailwind,
     mixBlendMode: {
       'screen': 'screen',
       'overlay': 'overlay',
     }
   },
-  
+
   ...
-  
+
   plugins: [
     // So we define it down here!
-    customNative({key: 'mixBlendMode'}),
+    customNative({ key: 'mixBlendMode' }),
     // There are extra parameters for further customization -- see the advanced usage section
   ]
 }
 ```
 
 this CSS is generated:
+
 ```css
 .mix-blend-mode-screen {
   mix-blend-mode: screen;
@@ -46,6 +49,7 @@ this CSS is generated:
 ```
 
 ### Variants
+
 When no variants are specified in the `variants` key of your config, no variants will be generated, as you saw above. (If you would prefer for `['responsive']` to be the default, I am open to changing it).
 
 If you want variants (in the same config as above):
@@ -56,22 +60,22 @@ const customNative = require('tailwindcss-custom-native');
 module.exports = {
   theme: {
     ...,
-    
+
     mixBlendMode: {
       'screen': 'screen',
       'overlay': 'overlay',
     }
   },
-  
+
   variants: {
     ...,
-    
+
     // All variants, whether added by plugin or not, are at your disposal
     mixBlendMode: ['hover', 'focus'],
   },
-  
+
   plugins: [
-    customNative({key: 'mixBlendMode'}),
+    customNative({ key: 'mixBlendMode' }),
   ]
 }
 ```
@@ -94,65 +98,84 @@ you get this additional CSS:
 }
 ```
 
-
 ## Advanced usage
+
 The complete function signature of `customNative` is:
+
 ```js
-function({ key, property, rename }, addUtilitiesOptions={}) {...}
+function({ key, property, rename, addUtilitiesOptions={} }) {...}
 ```
+
 Where each parameter means:
-* `key` (required, string) - The key name in the `theme` and `variants` section for your custom utility
-* `property` (optional, string) - The CSS property that your utility is for. When not specified, it defaults to kebab-casing (AKA hyphenating) the `key` (e.x. `key: 'animationTimingFunction'` has corresponding `property: 'animation-timing-function'`). You may want to use this in cases where your `key` name disagrees with the property name or you want to shorten it
-* `rename` (optional, string) - The preceding string that comes before each name (from your `theme` configuration) in the generated class name. When not specified, it defaults to kebab-casing (AKA hyphenating) the `key`. If set to the empty string (`''`), then there is no preceding name and each generated class name is just the name from each `theme` pair. See examples to clear things up
-* `addUtilitiesOptions` - Extra options to pass to the [`addUtilities`](https://next.tailwindcss.com/docs/plugins/#adding-utilities) function call. At the time of writing, this just means the [`respectPrefix` and `respectImportant`](https://next.tailwindcss.com/docs/plugins/#prefix-and-important-preferences) options
+
+- `key` (required, string) - The name of the key for your custom utility, as you wrote in the `theme` and `variants` section
+
+- `property` (optional, string) - The CSS property that your utility is for
+
+  When not specified, it defaults to kebab-casing (AKA hyphenating) the `key`. For example, `key: 'animationTimingFunction'` has corresponding `property: 'animation-timing-function'`).
+
+  This parameter allows you to use a `key` that may be shorter than the property name, or completely different from it.
+
+- `rename` (optional, string) - The prefix before each value name (from `theme[key]`) in the generated classes
+
+  When not specified, it defaults to kebab-casing (AKA hyphenating) the `key`. For example, `key: 'mixBlendMode'` has corresponding `rename: 'mix-blend-mode'`).
+
+  If set to the empty string (`''`), then there is no prefix and each generated class is just the value name.
+
+- `addUtilitiesOptions` - Extra options to pass to the [`addUtilities`](https://next.tailwindcss.com/docs/plugins/#adding-utilities) function call.
+
+  As of Tailwind 1.1.2, this just means the [`respectPrefix` and `respectImportant`](https://next.tailwindcss.com/docs/plugins/#prefix-and-important-preferences) options
 
 ## Examples
-Specifying `rename: ''` so you can write `blur-1` and `grayscale` instead of `filter-blur-1` or `filter-grayscale`:
+
+Specify `rename: ''` so you can write `blur-4` and `grayscale` instead of `filter-blur-4` and `filter-grayscale`:
 
 ```js
-const customNative = require('tailwindcss-custom-native');
+const customNative = require("tailwindcss-custom-native");
 
 module.exports = {
   theme: {
     extend: {
       filter: {
-      	'grayscale': 'grayscale(100%)',
-        'blur-4': 'blur(1rem)',
+        "grayscale": "grayscale(100%)",
+        "blur-4": "blur(1rem)"
       }
     }
   },
   variants: {
-    filter: ['responsive'],
+    filter: ["responsive"]
   },
   plugins: [
-    customNative({key: 'filter', rename: ''}),
+    customNative({ key: "filter", rename: "" }),
   ]
-}
+};
 ```
+
 ```css
 .grayscale {
-  filter: grayscale(100%)
+  filter: grayscale(100%);
 }
 
 .blur-4 {
-  filter: blur(1rem)
+  filter: blur(1rem);
 }
 
-// Or whatever screen `sm` is in your config
-@media (min-width: 640px)
+/* Or whatever screen `sm` is in your config */
+@media (min-width: 640px) {
   .sm\:grayscale {
-    filter: grayscale(100%)
+    filter: grayscale(100%);
   }
 
   .sm\:blur-4 {
-    filter: blur(1rem)
+    filter: blur(1rem);
   }
 }
 
 /* ... and so on for the other screens */
 ```
 
-Let's say you want a section specifically for blur utilities. Using `'blur'` as the key and `property: 'filter'`:
+Let's say you want a section specifically for blur utilities, because they *really* have nothing to do with other kinds of CSS filters. Use `'blur'` as the `key` and `'filter'` as the `property`:
+
 ```js
 const customNative = require('tailwindcss-custom-native');
 
@@ -171,138 +194,143 @@ module.exports = {
     blur: ['active'],
   },
   plugins: [
-    customNative({key: 'blur', property: 'filter'}),
+    customNative({ key: 'blur', property: 'filter' }),
   ]
 }
 ```
+
 ```css
 .blur-0 {
-  filter: blur(0)
+  filter: blur(0);
 }
 
 .blur-1 {
-  filter: blur(0.25rem)
+  filter: blur(0.25rem);
 }
 
 .blur-2 {
-  filter: blur(0.5rem)
+  filter: blur(0.5rem);
 }
 
 .active\:blur-0:active {
-  filter: blur(0)
+  filter: blur(0);
 }
 
 .active\:blur-1:active {
-  filter: blur(0.25rem)
+  filter: blur(0.25rem);
 }
 
 .active\:blur-2:active {
-  filter: blur(0.5rem)
+  filter: blur(0.5rem);
 }
 
 /* and so on for the other numbers you specified */
 ```
 
-You can (and probably will in practice) use the plugin more than once to create multiple utilities:
+In practice, you will probably use the plugin more than once because you need to create multiple custom utilities. Since version 0.1.0, you can chain multiple configurations into a single `customNative` call:
+
 ```js
-const customNative = require('tailwindcss-custom-native');
+const customNative = require("tailwindcss-custom-native");
 
 module.exports = {
   theme: {
-    extend: {
-      listStyleImage: {
-        'checkmark': "url('/img/checkmark.png')"
-      },
-      
-      scrollBehavior: {
-        'immediately': 'auto',
-        'smoothly': 'smooth'
-      }
+    listStyleImage: {
+      checkmark: "url('/img/checkmark.png')",
+    },
+
+    scrollBehavior: {
+      immediately: "auto",
+      smoothly: "smooth",
     }
   },
-  variants: {
-    
-  },
+  variants: {},
   plugins: [
-    customNative({key: 'listStyleImage', rename: 'list'}),
-    customNative({key: 'scrollBehavior', rename: 'scroll'}),
+    customNative(
+      { key: "listStyleImage", rename: "list" },
+      { key: "scrollBehavior", rename: "scroll" },
+    ),
   ]
-}
+};
 ```
+
 ```css
 .list-checkmark {
-  list-style-image: url('/img/checkmark.png')
+  list-style-image: url("/img/checkmark.png");
 }
 
 .scroll-immediately {
-  scroll-behavior: auto
+  scroll-behavior: auto;
 }
 
 .scroll-smoothly {
-  scroll-behavior: smooth
+  scroll-behavior: smooth;
 }
 ```
 
-Another good idea is to use it in conjunction with other plugins (especially ones that are missing relevant utilities or register new variants), in this case `tailwindcss-pseudo`:
+This plugin can piggyback off of other plugins, especially those that register new variants or are missing relevant utilities. 
+
+In this case, it is used to add some `content` utilities that have `before` and `after` pseudoselector variants, as provided by `tailwindcss-pseudo`:
+
 ```js
 module.exports = {
   theme: {
     extend: {
       content: {
-        'empty': "''",
-        'smile': "'\\1F60A'",
-        'checkmark': 'url(/img/checkmark.png)',
+        empty: "''",
+        smile: "'\\1F60A'",
+        checkmark: "url(/img/checkmark.png)",
       },
-      
+
       // This is tailwindcss-pseudo config
       pseudo: {
-        'before': 'before',
-        'after': 'after',
+        before: "before",
+        after: "after",
       }
     }
   },
   variants: {
-    content: ['before', 'after']
+    content: ["before", "after"]
   },
   plugins: [
     // Untested: this probably has to come first so that it can register the variant
-    require('tailwindcss-pseudo')(),
-    require('tailwindcss-custom-native')({key: 'content'}),
+    require("tailwindcss-pseudo")(),
+    require("tailwindcss-custom-native")({ key: "content" }),
   ]
-}
-
+};
 ```
+
 ```css
 .content-empty {
-  content: ''
+  content: "";
 }
 .content-smile {
-  content: '\1F60A'
+  content: "\1F60A";
 }
 .content-checkmark {
-  content: url(/img/checkmark.png)
+  content: url(/img/checkmark.png);
 }
 
 .before\:content-empty::before {
-  content: ''
+  content: "";
 }
 .before\:content-smile::before {
-  content: '\1F60A'
+  content: "\1F60A";
 }
 .before\:content-checkmark::before {
-  content: url(/img/checkmark.png)
+  content: url(/img/checkmark.png);
 }
 
 .after\:content-empty::after {
-  content: ''
+  content: "";
 }
 .after\:content-smile::after {
-  content: '\1F60A'
+  content: "\1F60A";
 }
 .after\:content-checkmark::after {
-  content: url(/img/checkmark.png)
+  content: url(/img/checkmark.png);
 }
 ```
 
 ## License and Contributing
+
 MIT licensed. There are no contributing guidelines. Just do whatever you want to point out an issue or feature request and I'll work with it.

--- a/index.js
+++ b/index.js
@@ -1,31 +1,55 @@
-const { kebabCase } = require('lodash');
+const { kebabCase } = require("lodash");
 
-module.exports = function({ key, property, rename }, addUtilitiesOptions={}) {
-	// E.x. 'mixBlendMode' -> 'mix-blend-mode'
-	const keyHyphenated = kebabCase(key);
-	
-	if (property === undefined) {
-		property = keyHyphenated;
-	}
-	
-	if (rename === undefined) {
-		rename = keyHyphenated;
-	}
-	
-	return ({addUtilities, e, theme, variants }) => {
-		const newUtilities = {};
-		
-		for (const [name, value] of Object.entries(theme(key, {}))) {
-			const className = rename === '' ? `.${e(`${name}`)}`: `.${e(`${rename}-${name}`)}`;
-			
-			newUtilities[className] = {
-				[property]: value,
-			};
-		}
-		
-		const specifiedVariants = variants(key, []);
-		
-		// This means a `variants` key in `addUtilitiesOptions` will override `specifiedVariants`!
-		addUtilities(newUtilities, {variants: specifiedVariants, ...addUtilitiesOptions});
-	};
+function single({ key, property, rename, addUtilitiesOptions }) {
+  // E.x. 'mixBlendMode' -> 'mix-blend-mode'
+  const keyHyphenated = kebabCase(key);
+
+  if (property === undefined) {
+    property = keyHyphenated;
+  }
+
+  if (rename === undefined) {
+    rename = keyHyphenated;
+  }
+
+  if (addUtilitiesOptions === undefined) {
+    addUtilitiesOptions = {};
+  }
+
+  return ({ addUtilities, e, theme, variants }) => {
+    const newUtilities = {};
+
+    for (const [name, value] of Object.entries(theme(key, {}))) {
+      const className = rename === "" ? `.${e(`${name}`)}` : `.${e(`${rename}-${name}`)}`;
+
+      newUtilities[className] = {
+        [property]: value
+      };
+    }
+
+    const specifiedVariants = variants(key, []);
+
+    // This means a `variants` key in `addUtilitiesOptions` will override `specifiedVariants`!
+    addUtilities(newUtilities, { variants: specifiedVariants, ...addUtilitiesOptions });
+  };
+}
+
+function multiple(...configurations) {
+  return pluginHelpers => {
+    configurations.forEach(configuration => single(configuration)(pluginHelpers));
+  };
+}
+
+module.exports = function(...args) {
+  // Determine which form of arguments is being used
+  if (args.length === 0) {
+    console.warn(
+      "customNative was called without any arguments; this can be fixed by passing at least one argument of the form { key, property, rename, addUtilitiesOptions }"
+    );
+  } else if (args.length === 2 && !args[1].hasOwnProperty("key")) {
+    // The old API is being used
+    return single({ ...args[0], addUtilitiesOptions: args[1] });
+  } else {
+    return multiple(...args);
+  }
 };


### PR DESCRIPTION
The `customNative` function is now variadic, so it can accept multiple configurations, meaning that what used to be written as:

```js
plugins: [customNative(config1), customNative(config2), customNative(config3)]
```

can now be written as:

```js
plugins: [customNative(config1, config2, config3)]
```

The documentation has been updated to reflect this.

This closes #2 